### PR TITLE
Fix hotkeys and labelling

### DIFF
--- a/src/classes/HotkeysContext.js
+++ b/src/classes/HotkeysContext.js
@@ -44,7 +44,9 @@ export class HotkeysContext {
         if (!this.enabled) {
           return;
         }
-        commands.run(command);
+        if (event.target.tagName !== 'INPUT') {
+          commands.run(command);
+        }
       });
 
     if (hotkey instanceof Array) {

--- a/src/classes/HotkeysContext.js
+++ b/src/classes/HotkeysContext.js
@@ -44,9 +44,7 @@ export class HotkeysContext {
         if (!this.enabled) {
           return;
         }
-
         commands.run(command);
-        event.preventDefault();
       });
 
     if (hotkey instanceof Array) {

--- a/src/redux/reducers/tools.js
+++ b/src/redux/reducers/tools.js
@@ -77,7 +77,6 @@ const tools = (state = { buttons: defaultButtons }, action) => {
   switch (action.type) {
     case 'SET_TOOL_ACTIVE':
       const item = state.buttons.find(button => button.command === action.tool);
-
       let buttons = [];
 
       if (item && item.type === 'tool') {
@@ -91,6 +90,7 @@ const tools = (state = { buttons: defaultButtons }, action) => {
           return button;
         });
       } else {
+        buttons = state.buttons;
         log.warn(`Tool ${action.tool} not found`);
       }
 


### PR DESCRIPTION
# Changes
- Fix hotkeys once we type a command that gets undefined and it was removing all buttons. 
- Fix labelling once we try to type things into the input of description or select-tree search, hotkeys was preventing the browser to add the key pressed into the input. 