### PR TITLE
Fix hotkeys bind

### DIFF
--- a/src/classes/HotkeysContext.js
+++ b/src/classes/HotkeysContext.js
@@ -1,5 +1,4 @@
 import log from '../log.js';
-import $ from 'jquery';
 import commands from '../commands';
 
 export class HotkeysContext {

--- a/src/hotkeys.js
+++ b/src/hotkeys.js
@@ -1,9 +1,7 @@
 import { HotkeysManager } from './classes/HotkeysManager';
 import jquery from 'jquery';
 window.$ = window.jQuery = jquery;
-
-// TODO: Need to remove this because it's breaking other usages..
-//import 'jquery.hotkeys';
+require('jquery.hotkeys');
 
 // Create hotkeys namespace using a HotkeysManager class instance
 const hotkeys = new HotkeysManager();


### PR DESCRIPTION
# Changes
- jquery.hotkeys was not being required
- using `import 'jquery.hotkeys';` throughs an error because the file imported looks for `this.jQuery` but `this` is undefined on the way its imported. quick solution was to use `require()`, as we are planing to remove jQuery from it, we will also remove this once jQuery is removed. 
