### PR TITLE
fix: 🐛 Handle changes to Bulk Data retrieval for Palette Color

### DIFF
--- a/src/studies/services/wado/retrieveMetadata.js
+++ b/src/studies/services/wado/retrieveMetadata.js
@@ -164,9 +164,10 @@ function getPaletteColor(server, instance, tag, lutDescriptor) {
     return byteArray[position] + byteArray[position + 1] * 256;
   };
 
-  const arrayBufferToPaletteColorLUT = arraybuffer => {
-    const byteArray = new Uint8Array(arraybuffer);
-    const lut = [];
+  const arrayBufferToPaletteColorLUT = result => {
+    const arraybuffer = result[0]
+    const byteArray = new Uint8Array(arraybuffer)
+    const lut = []
 
     for (let i = 0; i < numLutEntries; i++) {
       if (bits === 16) {


### PR DESCRIPTION
Previous versions of dicomweb-client retrieved BulkData as a single
entry, when the result should be provided as an array (the split-up
entries of the multipart response). This change just takes the first
entry of the split-up multipart response when handling Palette Color
images.