### PR TITLE
fix: 🐛 createStacks

### DIFF
--- a/src/utils/createStacks.js
+++ b/src/utils/createStacks.js
@@ -148,7 +148,12 @@ function createStacks(study) {
       sopClassUids
     );
 
+    const seriesData = series.getData();
+    const seriesDate = seriesData.seriesDate;
+
     if (displaySet) {
+      displaySet.seriesDate = seriesDate;
+
       displaySets.push(displaySet);
 
       return;
@@ -203,6 +208,13 @@ function createStacks(study) {
       });
       displaySets.push(displaySet);
     }
+  });
+
+  displaySets.sort((a, b) => {
+    const seriesDateA = a.seriesDate || a.getAttribute('seriesDate');
+    const seriesDateB = b.seriesDate || b.getAttribute('seriesDate');
+
+    return seriesDateA - seriesDateB;
   });
 
   return displaySets;


### PR DESCRIPTION
Add sorting by SeriesDate when creating the list of display sets

I guess this is sort of an enhancement, but it feels like a bug because the list of displaysets in the viewer always seems to show any measurement SRs first.