### PR TITLE
fix(getWADORSImageId): Fix incorrect imageId construction for WADO-RS

### DIFF
--- a/src/utils/getWADORSImageId.js
+++ b/src/utils/getWADORSImageId.js
@@ -9,7 +9,7 @@ function getWADORSImageUrl(instance, frame) {
   frame = (frame || 0) + 1;
 
   // Replaces /frame/1 by /frame/{frame}
-  wadorsuri = wadorsuri.replace(/(%2Fframes%2F)(\d+)/, `$1${frame}`);
+  wadorsuri = wadorsuri.replace(/frames\/(\d+)/, `frames/${frame}`);
 
   return wadorsuri;
 }


### PR DESCRIPTION
**fix(getWADORSImageId)**: Fix incorrect imageId construction for WADO-RS Multiframe instances

It looks like this was still written to handle things that had been passed through the Meteor version's WADO Proxy. The function was not properly replacing the frame number.

Related: https://github.com/OHIF/Viewers/issues/539

Thanks @vicOnGit75