### PR TITLE
fix(StudyMetadata): Gets the modality information from first series item

### DIFF
--- a/src/classes/metadata/StudyMetadata.js
+++ b/src/classes/metadata/StudyMetadata.js
@@ -635,7 +635,17 @@ function _getDisplaySetFromSopClassModule(
     headers,
   });
 
-  return plugin.getDisplaySetFromSeries(series, study, dicomWebClient, headers);
+  let displaySet = plugin.getDisplaySetFromSeries(
+    series,
+    study,
+    dicomWebClient,
+    headers
+  );
+  if (displaySet) {
+    const instance = series.getFirstInstance();
+    displaySet.modality = instance.getRawValue('x00080060');
+  }
+  return displaySet;
 }
 
 /**

--- a/src/classes/metadata/StudyMetadata.js
+++ b/src/classes/metadata/StudyMetadata.js
@@ -641,7 +641,7 @@ function _getDisplaySetFromSopClassModule(
     dicomWebClient,
     headers
   );
-  if (displaySet) {
+  if (displaySet && !displaySet.modality) {
     const instance = series.getFirstInstance();
     displaySet.modality = instance.getRawValue('x00080060');
   }


### PR DESCRIPTION
If the Display Set doesn't have the series image information, we were always adding SR for the modality, this change allows us to get this information from the first series instance.