### PR TITLE
fix(getWADORSImageUrl): Handle frame numbers that come in as strings

### DIFF
--- a/src/utils/getWADORSImageId.js
+++ b/src/utils/getWADORSImageId.js
@@ -6,7 +6,7 @@ function getWADORSImageUrl(instance, frame) {
   }
 
   // We need to sum 1 because WADO-RS frame number is 1-based
-  frame = (frame || 0) + 1;
+  frame = frame ? parseInt(frame) + 1 : 1;
 
   // Replaces /frame/1 by /frame/{frame}
   wadorsuri = wadorsuri.replace(/frames\/(\d+)/, `frames/${frame}`);

--- a/src/utils/getWADORSImageId.js
+++ b/src/utils/getWADORSImageId.js
@@ -18,6 +18,7 @@ function getWADORSImageUrl(instance, frame) {
  * Obtain an imageId for Cornerstone based on the WADO-RS scheme
  *
  * @param {object} instanceMetada metadata object (InstanceMetadata)
+ * @param {(string\|number)} [frame] the frame number
  * @returns {string} The imageId to be used by Cornerstone
  */
 export default function getWADORSImageId(instance, frame) {

--- a/src/utils/getWADORSImageId.test.js
+++ b/src/utils/getWADORSImageId.test.js
@@ -1,0 +1,65 @@
+import getWADORSImageId from './getWADORSImageId';
+
+describe('getWADORSImageId', () => {
+  it('should always return undefined if the instance has no `wadorsuri` property', () => {
+    const frame = '42';
+    const instance = {};
+
+    expect(getWADORSImageId(instance)).toBeUndefined();
+    expect(getWADORSImageId(instance, frame)).toBeUndefined();
+  });
+
+  it('should always prepend the `wadorsuri` with `wadors:`', () => {
+    const frame = '42';
+    const instance = {
+      wadorsuri: 'wadorsuri',
+    };
+
+    expect(getWADORSImageId(instance)).toEqual('wadors:wadorsuri');
+    expect(getWADORSImageId(instance, frame)).toEqual('wadors:wadorsuri');
+  });
+
+  describe('with no frame provided', () => {
+    it('should replace `frames/:number` with `frames/1`', () => {
+      const instance = {
+        wadorsuri: 'frames/42',
+      };
+
+      expect(getWADORSImageId(instance)).toEqual('wadors:frames/1');
+    });
+
+    it('should work on a real wadorsuri', () => {
+      const instance = {
+        wadorsuri:
+          'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs/studies/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.1/series/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.2/instances/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.8/frames/22',
+      };
+
+      expect(getWADORSImageId(instance)).toEqual(
+        'wadors:https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs/studies/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.1/series/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.2/instances/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.8/frames/1'
+      );
+    });
+  });
+
+  describe('with a frame provided', () => {
+    it('should replace `frames/:number` with the argument frame plus one', () => {
+      const frame = '42';
+      const instance = {
+        wadorsuri: 'frames/1',
+      };
+
+      expect(getWADORSImageId(instance, frame)).toEqual('wadors:frames/43');
+    });
+
+    it('should work on a real wadorsuri', () => {
+      const frame = '42';
+      const instance = {
+        wadorsuri:
+          'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs/studies/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.1/series/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.2/instances/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.8/frames/22',
+      };
+
+      expect(getWADORSImageId(instance, frame)).toEqual(
+        'wadors:https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs/studies/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.1/series/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.2/instances/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.8/frames/43'
+      );
+    });
+  });
+});


### PR DESCRIPTION
This surfaced as a result of some recent changes in ohif/Viewers Viewer.js. With those changes it
turned out that clearing the annotation was the first time that instance.getImageId() was called.
This sent it through a different execution path that was provided the frame number as a string,
exposing the issue this PR resolves.